### PR TITLE
Add placeholder service directories

### DIFF
--- a/services/api-gateway/Dockerfile.dev
+++ b/services/api-gateway/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/api-gateway/README.md
+++ b/services/api-gateway/README.md
@@ -1,0 +1,3 @@
+# api-gateway
+
+Placeholder for the api-gateway.

--- a/services/auth-service/Dockerfile.dev
+++ b/services/auth-service/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/auth-service/README.md
+++ b/services/auth-service/README.md
@@ -1,0 +1,3 @@
+# auth-service
+
+Placeholder for the auth-service.

--- a/services/collaboration-service/Dockerfile.dev
+++ b/services/collaboration-service/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/collaboration-service/README.md
+++ b/services/collaboration-service/README.md
@@ -1,0 +1,3 @@
+# collaboration-service
+
+Placeholder for the collaboration-service.

--- a/services/frontend/Dockerfile.dev
+++ b/services/frontend/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -1,0 +1,3 @@
+# frontend
+
+Placeholder for the frontend.

--- a/services/llm-service/Dockerfile.dev
+++ b/services/llm-service/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/llm-service/README.md
+++ b/services/llm-service/README.md
@@ -1,0 +1,3 @@
+# llm-service
+
+Placeholder for the llm-service.

--- a/services/prompt-service/Dockerfile.dev
+++ b/services/prompt-service/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/prompt-service/README.md
+++ b/services/prompt-service/README.md
@@ -1,0 +1,3 @@
+# prompt-service
+
+Placeholder for the prompt-service.

--- a/services/testing-service/Dockerfile.dev
+++ b/services/testing-service/Dockerfile.dev
@@ -1,0 +1,3 @@
+FROM node:18-alpine
+WORKDIR /app
+CMD ["sleep", "infinity"]

--- a/services/testing-service/README.md
+++ b/services/testing-service/README.md
@@ -1,0 +1,3 @@
+# testing-service
+
+Placeholder for the testing-service.


### PR DESCRIPTION
## Summary
- scaffold microservice directories under `services/`
- add placeholder `Dockerfile.dev` and README files for each service

## Testing
- `npm test` *(fails: Missing script "test:all")*

------
https://chatgpt.com/codex/tasks/task_e_686dca9d80c48322858d9f930bff44dc