### PR TITLE
Add Python requirements files

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+fastapi==0.110.0
+uvicorn[standard]==0.29.0
+httpx==0.27.0
+pydantic==2.7.1
+SQLAlchemy==2.0.29
+asyncpg==0.29.0
+python-dotenv==1.0.1

--- a/services/api-gateway/requirements.txt
+++ b/services/api-gateway/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/auth-service/requirements.txt
+++ b/services/auth-service/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/collaboration-service/requirements.txt
+++ b/services/collaboration-service/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/frontend/requirements.txt
+++ b/services/frontend/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/llm-service/requirements.txt
+++ b/services/llm-service/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/prompt-service/requirements.txt
+++ b/services/prompt-service/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt

--- a/services/testing-service/requirements.txt
+++ b/services/testing-service/requirements.txt
@@ -1,0 +1,3 @@
+# Service-specific dependencies
+
+-r ../../requirements.txt


### PR DESCRIPTION
## Summary
- add top-level requirements.txt with common deps
- scaffold per-service requirements files referencing the root list

## Testing
- `pytest services/prompts/tests/ -v --cov=services/prompts` *(fails: file or directory not found)*
- `npm test -- --coverage --watchAll=false` *(fails: missing script `test:all`)*

------
https://chatgpt.com/codex/tasks/task_e_686dcbb23e408322952a70ec3cc043dc